### PR TITLE
[Counter]: Implement ring buffer for days of the week

### DIFF
--- a/managers/def/manager.go
+++ b/managers/def/manager.go
@@ -156,7 +156,7 @@ func (m *defaultUrlManager) deleteShortUrlFromDb(key string) error {
 
 func (m *defaultUrlManager) generateShortUrl(longUrl string, expiry time.Duration) urls.ShortUrl {
 	hash := md5.Sum([]byte(longUrl))
-	hashStr := base64.StdEncoding.EncodeToString(hash[:])
+	hashStr := base64.URLEncoding.EncodeToString(hash[:])
 	shortUrl, ok := m.cache[hashStr]
 
 	if ok {


### PR DESCRIPTION
This PR makes a large improvement in memory by reducing the amount of historical data the Counter stores. We now store the total number of calls in an integer counter and use a ring buffer to store calls for the past 7 days.